### PR TITLE
fix: upgrade to Go 1.22 for GCP runtime compatibility

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module keepersecurity.com/ksm-scim
 
-go 1.21
+go 1.22
 
 require (
 	github.com/GoogleCloudPlatform/functions-framework-go v1.8.0


### PR DESCRIPTION
## Summary

Upgrades Go version from 1.21 to 1.22 to maintain compatibility with Google Cloud Platform Cloud Functions runtime requirements.

## Problem

GCP is deprecating Go 1.21 runtime:
- Deprecation date: September 3, 2025 (already passed)
- Hard deadline: March 3, 2026 (41 days away)
- After March 3, GCP Cloud Functions will reject Go 1.21 deployments

## Changes

- Updated `go.mod` from `go 1.21` to `go 1.22`
- Ran `go mod tidy` to refresh dependencies
- Verified build succeeds with `go build ./...`

## Testing

- Build successful (`go build ./...`)
- Dependencies resolved (`go mod tidy`)
- No breaking changes detected

## Impact

- Ensures continued functionality on GCP Cloud Functions after March 3, 2026
- No code changes required - only Go version bump
- Minimal risk (Go 1.22 is fully compatible with Go 1.21 code)

## Note on Security Vulnerabilities

GitHub reports 10 vulnerabilities on this repo (1 critical, 2 high, 7 moderate). These are separate issues that should be addressed in follow-up PRs:
- 3 open Dependabot PRs (#10, #11, #12) from 2024
- Recommend merging those PRs after this one

Fixes #13